### PR TITLE
Don't delete copy constructor when rvalue references are disabled

### DIFF
--- a/include/boost/move/core.hpp
+++ b/include/boost/move/core.hpp
@@ -20,7 +20,7 @@
 
 //boost_move_no_copy_constructor_or_assign typedef
 //used to detect noncopyable types for other Boost libraries.
-#if defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+#if defined(BOOST_NO_CXX11_DELETED_FUNCTIONS) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
    #define BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE) \
       private:\
       TYPE(TYPE &);\


### PR DESCRIPTION
Before SVN r82706 from February 2013 (git a7091d1009f057b1148b36fabf91f83667db5f72), Boost.Move worked perfectly for compilers that supported deleted functions without supporting rvalue references (for example, clang with libstdc++ 4.2.1 on Mac to support OS X 10.6). r82706 broke those setups as temporaries now call the deleted copy constructor instead of the move constructor. This change reverts those setups to the old behavior.
