### PR TITLE
Avoided GCC 4.9 regression in C++14 mode

### DIFF
--- a/include/boost/move/core.hpp
+++ b/include/boost/move/core.hpp
@@ -253,9 +253,17 @@
 
    //Compiler workaround detection
    #if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
-      #if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 5) && !defined(__clang__)
-         //Pre-standard rvalue binding rules
-         #define BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+      #if defined(__GNUC__) && !defined(__clang__)
+         #if (__GNUC__ == 4) && (__GNUC_MINOR__ < 5)
+            //Pre-standard rvalue binding rules
+            #define BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+         #endif
+         #if ((__GNUC__ == 4) && (__GNUC_MINOR__ == 9) && (__GNUC_PATCHLEVEL__ < 2)) && \
+             (201103L < __cplusplus)
+            // GCC 4.9 doesn't compile parenthesized return statement in C++14 mode.
+            // https://gcc.gnu.org/PR63437
+            #define BOOST_MOVE_GCC_PARENTHESIZED_RETURN_STMT_BUG
+         #endif
       #elif defined(_MSC_VER) && (_MSC_VER == 1600)
          //Standard rvalue binding rules but with some bugs
          #define BOOST_MOVE_MSVC_10_MEMBER_RVALUE_REF_BUG
@@ -372,10 +380,12 @@
 
    #endif   //#if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
 
-   #if !defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   #if !(defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || \
+         defined(BOOST_MOVE_GCC_PARENTHESIZED_RETURN_STMT_BUG)) || \
+       defined(BOOST_MOVE_DOXYGEN_INVOKED)
 
       //!This macro is used to achieve portable move return semantics.
-      //!The C++11 Standard allows implicit move returns when the object to be returned 
+      //!The C++11 Standard allows implicit move returns when the object to be returned
       //!is designated by a lvalue and:
       //!   - The criteria for elision of a copy operation are met OR
       //!   - The criteria would be met save for the fact that the source object is a function parameter
@@ -398,7 +408,9 @@
          (REF)
       //
 
-   #else //!defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   #else //!(defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) ||
+         //  defined(BOOST_MOVE_GCC_PARENTHESIZED_RETURN_STMT_BUG)) ||
+         //defined(BOOST_MOVE_DOXYGEN_INVOKED)
 
       #include <boost/move/detail/meta_utils.hpp>
 
@@ -430,7 +442,9 @@
          boost::move_detail::move_return< RET_TYPE >(REF)
       //
 
-   #endif   //!defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   #endif   //!(defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) ||
+            //  defined(BOOST_MOVE_GCC_PARENTHESIZED_RETURN_STMT_BUG)) ||
+            //defined(BOOST_MOVE_DOXYGEN_INVOKED)
 
    namespace boost {
    namespace move_detail {


### PR DESCRIPTION
GCC 4.9.0 and 4.9.1 have a regression: don't compile parenthesized return stmt in C++14 mode.

```
movable f()
{
    movable m;
    return (m); // bug on here
}
```

This PR will fix [BP x86_64 C++11 - move - doc_move_return / gcc-4.9.1~c14](http://www.boost.org/development/tests/develop/developer/output/BP%20x86_64%20C++11-boost-bin-v2-libs-move-example-doc_move_return-test-gcc-4-9-1~c14-debug-debug-symbols-off-link-static.html), and other test failures.

For more details, see: https://gcc.gnu.org/PR63437 .
