### PR TITLE
Add support for BOOST_NO_INTRINSIC_WCHAR_T

### DIFF
--- a/include/boost/move/detail/type_traits.hpp
+++ b/include/boost/move/detail/type_traits.hpp
@@ -400,7 +400,9 @@ template<> struct is_integral_cv<                 char16_t>{  static const bool 
 #ifndef BOOST_NO_CXX11_CHAR32_T
 template<> struct is_integral_cv<                 char32_t>{  static const bool value = true; };
 #endif
+#ifndef BOOST_NO_INTRINSIC_WCHAR_T
 template<> struct is_integral_cv<                  wchar_t>{  static const bool value = true; };
+#endif
 template<> struct is_integral_cv<                    short>{  static const bool value = true; };
 template<> struct is_integral_cv<           unsigned short>{  static const bool value = true; };
 template<> struct is_integral_cv<                      int>{  static const bool value = true; };


### PR DESCRIPTION
This fixes a compile error in lexical_cast's lexical_cast_typedefed_wchar_test_runtime regression test with MSVC.