### PR TITLE
Fix for BOOST_ALIGNMENT_OF being set to an "unknown" value.

### DIFF
--- a/include/boost/move/detail/type_traits.hpp
+++ b/include/boost/move/detail/type_traits.hpp
@@ -847,7 +847,7 @@ struct alignment_of_impl
     // Using a combination of the two seems to make the most of a bad job:
    : alignment_logic< sizeof(alignment_of_hack<T>) - 2*sizeof(T), __alignof(T)>
 {};
-#elif !defined(BOOST_ALIGNMENT_OF)
+#elif !defined(BOOST_MOVE_ALIGNMENT_OF)
    : alignment_logic< sizeof(alignment_of_hack<T>) - 2*sizeof(T), sizeof(T)>
 {};
 #else


### PR DESCRIPTION
Leaving aside the wisdom of creating your own type_traits for a moment, if BOOST_ALIGNMENT_OF is set for a new compiler (for example the Solaris-12.4 compiler) then this code breaks.  The patch at least makes sure it compiles.