### PR TITLE
Remove mentions of deprecated macros in test

### DIFF
--- a/test/adl_move_swap.cpp
+++ b/test/adl_move_swap.cpp
@@ -91,7 +91,7 @@ int main()
       movable x, y;
       swap_stats::reset_stats();
       ::boost::adl_move_swap(x, y);
-      #if defined(BOOST_NO_RVALUE_REFERENCES)
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
       //In non rvalue reference compilers,
       //movable classes with no swap() member uses
       //boost::move() to implement swap.
@@ -117,7 +117,7 @@ int main()
       movable_swap_member x, y;
       swap_stats::reset_stats();
       ::boost::adl_move_swap(x, y);
-      #if defined(BOOST_NO_RVALUE_REFERENCES)
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
       //In non rvalue reference compilers,
       //movable classes with no swap() member uses
       //boost::move() to implement swap.


### PR DESCRIPTION
Change uses of `BOOST_NO_RVALUE_REFERENCES`, which was deprecated in Boost 1.51.0, to use `BOOST_NO_CXX11_RVALUE_REFERENCES` instead.

No functionality change.
