### PR TITLE
Corrected incorrect include of no_exceptions_support.hpp.

### DIFF
--- a/include/boost/move/algo/move.hpp
+++ b/include/boost/move/algo/move.hpp
@@ -27,7 +27,7 @@
 #include <boost/move/utility_core.hpp>
 #include <boost/move/detail/iterator_traits.hpp>
 #include <boost/move/detail/iterator_to_raw_pointer.hpp>
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 
 namespace boost {
 

--- a/include/boost/move/algorithm.hpp
+++ b/include/boost/move/algorithm.hpp
@@ -27,7 +27,7 @@
 #include <boost/move/utility_core.hpp>
 #include <boost/move/iterator.hpp>
 #include <boost/move/algo/move.hpp>
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 
 #include <algorithm> //copy, copy_backward
 #include <memory>    //uninitialized_copy


### PR DESCRIPTION
This file appears to have been moved from the `detail` module to the `core` module on 6/2014 in `core` commit 60c9a35d8 (`detail` commit 099854de). It appears that some package managers' Boost distributions have duplicate copies of the file to work around the error.