### PR TITLE
Adds support for MSVC ARM64 target.

### DIFF
--- a/include/boost/move/detail/unique_ptr_meta_utils.hpp
+++ b/include/boost/move/detail/unique_ptr_meta_utils.hpp
@@ -446,7 +446,7 @@ class is_convertible
 #define BOOST_MOVE_TT_DECL
 #endif
 
-#if defined(_MSC_EXTENSIONS) && !defined(__BORLAND__) && !defined(_WIN64) && !defined(_M_ARM) && !defined(UNDER_CE)
+#if defined(_MSC_EXTENSIONS) && !defined(__BORLAND__) && !defined(_WIN64) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(UNDER_CE)
 #define BOOST_MOVE_TT_TEST_MSC_FUNC_SIGS
 #endif
 


### PR DESCRIPTION
Takes predefined macro _M_ARM64 in VS2015+ to detect ARM64 target.