### PR TITLE
Workaround for bogus [-Wignored-attributes] warning on GCC 6.x/7.x

### DIFF
--- a/include/boost/move/detail/type_traits.hpp
+++ b/include/boost/move/detail/type_traits.hpp
@@ -967,14 +967,13 @@ typedef union max_align max_align_t;
 #if !defined(BOOST_NO_ALIGNMENT)
 
 template<std::size_t Len, std::size_t Align>
-struct aligned_storage_impl;
+struct aligned_struct;
 
 #define BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(A)\
 template<std::size_t Len>\
-struct BOOST_ALIGNMENT(A) aligned_storage_impl<Len, A>\
+struct BOOST_ALIGNMENT(A) aligned_struct<Len, A>\
 {\
    char dummy[Len];\
-   typedef aligned_storage_impl<Len, A> type;\
 };\
 //
 
@@ -994,6 +993,20 @@ BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x800)
 BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x1000)
 
 #undef BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT
+
+// Workaround for bogus [-Wignored-attributes] warning on GCC 6.x/7.x: don't use a type that "directly" carries the alignment attribute.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82270
+template<std::size_t Len, std::size_t Align>
+struct aligned_struct_wrapper
+{
+   aligned_struct<Len, Align> dummy;
+};
+
+template<std::size_t Len, std::size_t Align>
+struct aligned_storage_impl
+{
+   typedef aligned_struct_wrapper<Len, Align> type;
+};
 
 #else //BOOST_NO_ALIGNMENT
 


### PR DESCRIPTION
I've executed the Boost.Move and Boost.Container tests with GCC 6.3 & MSVC 2017 => pass.

I've also verified the general "technique" (wrapping the struct with the alignment attribute in another struct) with several GCC, ICC and Clang versions, and it seems to work fine - i.e. no bugs where the compiler "loses" the alignment for the wrapper struct or the wrapper struct comes out with an unexpected size.

So I guess this should be safe.