### PR TITLE
Add a test for broken move emulation on gcc < 6

### DIFF
--- a/test/move_noinline.cpp
+++ b/test/move_noinline.cpp
@@ -1,0 +1,55 @@
+#include <boost/move/core.hpp>
+#include <boost/move/move.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+class movable_v2 {
+public:
+    movable_v2() : value_(1) {}
+
+private:
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(movable_v2)
+
+public:
+    movable_v2(BOOST_RV_REF(movable_v2) m)
+    {
+        value_ = m.value_;
+        m.value_ = 0;
+    }
+    movable_v2& operator=(BOOST_RV_REF(movable_v2) m);
+
+    bool moved() const
+    { return !value_; }
+
+private:
+    int value_;
+};
+
+movable_v2& movable_v2::operator=(BOOST_RV_REF(movable_v2) m)
+{
+    if (this != &m) {
+        value_ = m.value_;
+        m.value_ = 0;
+    }
+    return *this;
+}
+
+namespace boost{
+
+template<>
+struct has_nothrow_move<movable_v2>
+{
+    static const bool value = true;
+};
+
+} // namespace boost
+
+int main()
+{
+    movable_v2 m;
+    movable_v2 m2;
+
+    m2 = ::boost::move(m);
+    BOOST_TEST(m.moved());
+    BOOST_TEST_NOT(m2.moved());
+    return 0;
+}

--- a/test/move_noinline.cpp
+++ b/test/move_noinline.cpp
@@ -51,5 +51,5 @@ int main()
     m2 = ::boost::move(m);
     BOOST_TEST(m.moved());
     BOOST_TEST_NOT(m2.moved());
-    return 0;
+    return boost::report_errors();
 }


### PR DESCRIPTION
This is an example for  broken move emulation on gcc < 6. (Issue #16 )

```
gcc.compile.c++ ../../bin.v2/libs/move/test/move_noinline.test/gcc-5/debug/move_noinline.o
test/move_noinline.cpp:27:14: error: prototype for 'moveable_v2& moveable_v2::operator=(boost::rv<moveable_v2>&)' does not match any in class 'moveable_v2'
 moveable_v2& moveable_v2::operator=(BOOST_RV_REF(moveable_v2) m)
              ^
test/move_noinline.cpp:18:18: error: candidates are: moveable_v2& moveable_v2::operator=(boost::rv<moveable_v2>&)
     moveable_v2& operator=(BOOST_RV_REF(moveable_v2) m);
                  ^
In file included from test/move_noinline.cpp:1:0:
../../boost/move/core.hpp:38:13: error:                 moveable_v2& moveable_v2::operator=(moveable_v2&)
       TYPE& operator=(TYPE &);\
```

Tested with gcc 4.9, 5, 6, 7 in Ubuntu 16.04.
