### PR TITLE
Fix gcc 9 deprecated copy warnings in antistable.

### DIFF
--- a/include/boost/move/algo/predicate.hpp
+++ b/include/boost/move/algo/predicate.hpp
@@ -28,6 +28,10 @@ struct antistable
       : m_comp(comp)
    {}
 
+   antistable(const antistable & other)
+      : m_comp(other.m_comp)
+   {}
+
    template<class U, class V>
    bool operator()(const U &u, const V & v)
    {  return !m_comp(v, u);  }


### PR DESCRIPTION
Hi,

Without this, when using boost container's flat_map/flat_set, I am having depecated copy warnings in gcc 9. If I declare the copy constructor private (or deleted) then it does not compile anymore, so I assume copy constructor is really needed.

Cheers,
Romain