### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __CODEGEARC__ to BOOST_CODEGEARC, which is defined in Boost co…

### DIFF
--- a/include/boost/move/detail/type_traits.hpp
+++ b/include/boost/move/detail/type_traits.hpp
@@ -193,7 +193,7 @@
 #   define BOOST_MOVE_ALIGNMENT_OF(T) __alignof__(T)
 #endif
 
-# if defined(__CODEGEARC__)
+# if defined(BOOST_CODEGEARC)
 #   define BOOST_MOVE_IS_UNION(T) __is_union(T)
 #   define BOOST_MOVE_IS_POD(T) __is_pod(T)
 #   define BOOST_MOVE_IS_EMPTY(T) __is_empty(T)

--- a/include/boost/move/detail/unique_ptr_meta_utils.hpp
+++ b/include/boost/move/detail/unique_ptr_meta_utils.hpp
@@ -546,7 +546,7 @@ struct is_unary_function
 #  define BOOST_MOVEUP_HAS_VIRTUAL_DESTRUCTOR(T) __has_virtual_destructor(T)
 #elif defined(__ghs__) && (__GHS_VERSION_NUMBER >= 600)
 #  define BOOST_MOVEUP_HAS_VIRTUAL_DESTRUCTOR(T) __has_virtual_destructor(T)
-#elif defined(__CODEGEARC__)
+#elif defined(BOOST_CODEGEARC)
 #  define BOOST_MOVEUP_HAS_VIRTUAL_DESTRUCTOR(T) __has_virtual_destructor(T)
 #endif
 


### PR DESCRIPTION
…nfig for the Embarcadero non-clang-based compilers.