### PR TITLE
Iterator traits/use std

### DIFF
--- a/include/boost/move/detail/iterator_traits.hpp
+++ b/include/boost/move/detail/iterator_traits.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <cstddef>
+#include <iterator>
 #include <boost/move/detail/type_traits.hpp>
 
 #include <boost/move/detail/std_ns_begin.hpp>
@@ -40,36 +41,15 @@ BOOST_MOVE_STD_NS_END
 
 namespace boost{  namespace movelib{
 
-template<class Iterator>
-struct iterator_traits
+template <typename T>
+struct iterator_traits : std::iterator_traits<T>
 {
-   typedef typename Iterator::difference_type   difference_type;
-   typedef typename Iterator::value_type        value_type;
-   typedef typename Iterator::pointer           pointer;
-   typedef typename Iterator::reference         reference;
-   typedef typename Iterator::iterator_category iterator_category;
-   typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
-};
+   typedef typename std::iterator_traits<T>::difference_type difference_type;
+   typedef typename std::iterator_traits<T>::pointer pointer;
+   typedef typename std::iterator_traits<T>::reference reference;
+   typedef typename std::iterator_traits<T>::iterator_category iterator_category;
+   typedef typename std::iterator_traits<T>::value_type value_type;
 
-template<class T>
-struct iterator_traits<T*>
-{
-   typedef std::ptrdiff_t                    difference_type;
-   typedef T                                 value_type;
-   typedef T*                                pointer;
-   typedef T&                                reference;
-   typedef std::random_access_iterator_tag   iterator_category;
-   typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
-};
-
-template<class T>
-struct iterator_traits<const T*>
-{
-   typedef std::ptrdiff_t                    difference_type;
-   typedef T                                 value_type;
-   typedef const T*                          pointer;
-   typedef const T&                          reference;
-   typedef std::random_access_iterator_tag   iterator_category;
    typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
 };
 


### PR DESCRIPTION
Using Boost.Move breaks range-v3, since the latter specializes std::iterator_traits for its custom iterators, but does not provide all member type aliases.

See https://github.com/ericniebler/range-v3/pull/1660