### PR TITLE
Include <algorithm> when BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE is defined

### DIFF
--- a/include/boost/move/algo/move.hpp
+++ b/include/boost/move/algo/move.hpp
@@ -28,6 +28,9 @@
 #include <boost/move/detail/iterator_traits.hpp>
 #include <boost/move/detail/iterator_to_raw_pointer.hpp>
 #include <boost/core/no_exceptions_support.hpp>
+#if defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+#include <algorithm>
+#endif
 
 namespace boost {
 


### PR DESCRIPTION
When directly using <boost/move/algo/move.hpp> without including it through <boost/move/move.hpp> (which includes <algorithm>), one stumbles upon the error like this one:
```
In file included from boost/boost/container/flat_set.hpp:29:
In file included from boost/boost/container/detail/flat_tree.hpp:30:
In file included from boost/boost/container/vector.hpp:60:
In file included from boost/boost/move/algo/adaptive_merge.hpp:16:
In file included from boost/boost/move/algo/detail/adaptive_sort_merge.hpp:48:
boost/boost/move/algo/move.hpp:91:10: error: no member named 'move_backward' in namespace 'std'; did you mean 'container::move_backward'?
using ::std::move_backward;
      ^~~~~~~
boost/boost/container/detail/copy_move_algo.hpp:893:4: note: 'container::move_backward' declared here
move_backward(I f, I l, F r)
^
```

Another solution would be to include <boost/move/algorithm.hpp>, but it's unnecessary.