### PR TITLE
Lowercase windows.h

### DIFF
--- a/include/boost/move/detail/nsec_clock.hpp
+++ b/include/boost/move/detail/nsec_clock.hpp
@@ -43,7 +43,7 @@
 #include <cassert>
 
 #if defined( BOOST_USE_WINDOWS_H )
-#include <Windows.h>
+#include <windows.h>
 #else
 
 #if defined (WIN32_PLATFORM_PSPC)


### PR DESCRIPTION
Errors when cross-compiling on a case-sensitive fs (mingw) Will make no difference on windows where the fs is case-insensitive