### PR TITLE
Avoid -Wdeprecated-variadic-comma-omission with GCC 15 trunk -std=c++26

### DIFF
--- a/include/boost/move/detail/unique_ptr_meta_utils.hpp
+++ b/include/boost/move/detail/unique_ptr_meta_utils.hpp
@@ -497,7 +497,7 @@ struct is_unary_function_impl<R (*)(T0)>
 {  static const bool value = true;  };
 
 template <typename R, class T0>
-struct is_unary_function_impl<R (*)(T0...)>
+struct is_unary_function_impl<R (*)(T0, ...)>
 {  static const bool value = true;  };
 
 #else // BOOST_MOVE_TT_TEST_MSC_FUNC_SIGS
@@ -519,7 +519,7 @@ struct is_unary_function_impl<R (__cdecl*)(T0)>
 {  static const bool value = true;  };
 
 template <typename R, class T0>
-struct is_unary_function_impl<R (__cdecl*)(T0...)>
+struct is_unary_function_impl<R (__cdecl*)(T0, ...)>
 {  static const bool value = true;  };
 
 #endif


### PR DESCRIPTION
...since
<https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=cc67d95dc100706ea665e8cce581d59466aba62e> "c++: Implement C++26 P3176R1 - The Oxford variadic comma"