### PR TITLE
Add std::pair specializations for trivial type traits

### DIFF
--- a/include/boost/move/detail/type_traits.hpp
+++ b/include/boost/move/detail/type_traits.hpp
@@ -33,6 +33,7 @@
 #include <cassert>
 // std
 #include <cstddef>
+#include <utility>
 
 //Use of Boost.TypeTraits leads to long preprocessed source code due to
 //MPL dependencies. We'll use intrinsics directly and make or own
@@ -1032,6 +1033,11 @@ template<class T>
 struct is_trivially_destructible
 {  static const bool value = BOOST_MOVE_IS_TRIVIALLY_DESTRUCTIBLE(T); };
 
+template<class A, class B>
+struct is_trivially_destructible<std::pair<A,B> >
+{  static const bool value = is_trivially_destructible<A>::value &&
+                             is_trivially_destructible<B>::value; };
+
 //////////////////////////////////////
 //       is_trivially_default_constructible
 //////////////////////////////////////
@@ -1048,12 +1054,22 @@ struct is_trivially_copy_constructible
    static const bool value = BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T);
 };
 
+template<class A, class B>
+struct is_trivially_copy_constructible<std::pair<A,B> >
+{  static const bool value = is_trivially_copy_constructible<A>::value &&
+                             is_trivially_copy_constructible<B>::value; };
+
 //////////////////////////////////////
 //       is_trivially_move_constructible
 //////////////////////////////////////
 template<class T>
 struct is_trivially_move_constructible
 { static const bool value = BOOST_MOVE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE(T); };
+
+template<class A, class B>
+struct is_trivially_move_constructible<std::pair<A,B> >
+{  static const bool value = is_trivially_move_constructible<A>::value &&
+                             is_trivially_move_constructible<B>::value; };
 
 //////////////////////////////////////
 //       is_trivially_copy_assignable
@@ -1062,7 +1078,12 @@ template<class T>
 struct is_trivially_copy_assignable
 {
    static const bool value = BOOST_MOVE_IS_TRIVIALLY_COPY_ASSIGNABLE(T);
-};                             
+};
+
+template<class A, class B>
+struct is_trivially_copy_assignable<std::pair<A,B> >
+{  static const bool value = is_trivially_copy_assignable<A>::value &&
+                             is_trivially_copy_assignable<B>::value; };
 
 //////////////////////////////////////
 //       is_trivially_move_assignable
@@ -1070,6 +1091,11 @@ struct is_trivially_copy_assignable
 template<class T>
 struct is_trivially_move_assignable
 {  static const bool value = BOOST_MOVE_IS_TRIVIALLY_MOVE_ASSIGNABLE(T);  };
+
+template<class A, class B>
+struct is_trivially_move_assignable<std::pair<A,B> >
+{  static const bool value = is_trivially_move_assignable<A>::value &&
+                             is_trivially_move_assignable<B>::value; };
 
 //////////////////////////////////////
 //       is_nothrow_default_constructible

--- a/include/boost/move/traits.hpp
+++ b/include/boost/move/traits.hpp
@@ -29,6 +29,7 @@
 #endif
 #include <boost/move/detail/meta_utils.hpp>
 #include <boost/move/detail/type_traits.hpp>
+#include <utility>
 
 namespace boost {
 
@@ -45,6 +46,11 @@ template <class T>
 struct has_trivial_destructor_after_move
    : ::boost::move_detail::is_trivially_destructible<T>
 {};
+
+template<class A, class B>
+struct has_trivial_destructor_after_move<std::pair<A,B> >
+{  static const bool value = has_trivial_destructor_after_move<A>::value &&
+                             has_trivial_destructor_after_move<B>::value; };
 
 //! By default this traits returns
 //! <pre>boost::is_nothrow_move_constructible<T>::value && boost::is_nothrow_move_assignable<T>::value </pre>.


### PR DESCRIPTION
Move the std::pair<A,B> partial specializations for the following traits from boost/container/detail/pair.hpp to the headers where the primary templates are defined:

  - is_trivially_destructible        (type_traits.hpp)
  - is_trivially_copy_constructible  (type_traits.hpp)
  - is_trivially_move_constructible  (type_traits.hpp)
  - is_trivially_copy_assignable     (type_traits.hpp)
  - is_trivially_move_assignable     (type_traits.hpp)
  - has_trivial_destructor_after_move (traits.hpp)

When the specializations live in pair.hpp (included late via flat_map.hpp), GCC diagnoses "partial specialization of '...' after instantiation of '...'" in unity/jumbo builds or any translation unit that implicitly instantiates a trait for std::pair before pair.hpp is included.  This is a regression introduced in Boost 1.88/1.90 by commit 9552828 and is the same class of bug as Trac #12534.

The new specializations implement direct member-wise checks (trait<A>::value && trait<B>::value) instead of inheriting from the dtl::pair specializations, so they are self-contained within Boost.Move.

Fixes: https://github.com/boostorg/container/issues/330