### PR TITLE
Enable adding Ubuntu toolchain PPA by default

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -8,7 +8,7 @@
 # As the yaml syntax for Drone CI is rather limited.
 #
 #
-globalenv={'B2_CI_VERSION': '0', 'B2_VARIANT': 'variant=release,debug'}
+globalenv={'B2_CI_VERSION': '0', 'ADD_UBUNTU_TOOLCHAIN_PPA': 'true', 'B2_VARIANT': 'variant=release,debug'}
 linuxglobalimage="cppalliance/droneubuntu1604:1"
 windowsglobalimage="cppalliance/dronevs2019"
 


### PR DESCRIPTION
The default in Boost.CI will be false but some jobs still rely on this, so keep it for now the default.